### PR TITLE
Phase 1.1: CounterpartyType enrichment + PR.CPartyType predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ The engine follows a rule-based design: a JSON catalog describing routing rules 
 
 This structure keeps the rule engine composable: hosts can feed different catalogs, enrich the `RoutingContext`, or extend predicate generation without altering the core evaluation flow.
 
+### Enrichment (Phase 1.1)
+- The engine now supports an optional derived attribute `counterparty.type` (enum PERSON | BUSINESS | UNKNOWN) exposed to rules via `PR.CPartyType`.
+- Recommended usage: run your classifier (e.g., name/entity model) in your host application and populate `CounterpartyContext.Type` before calling `RoutingEngine.Evaluate(...)`.
+- Why: keeps the evaluator deterministic and fast, and makes rules explicit about targeting enriched data.
+- Contract updates: OpenAPI request includes `counterparty.type`; rules may specify `PR.CPartyType`. Missing values behave as wildcards (no condition generated).
+
 ## Prerequisites
 - .NET 9 SDK (build 9.0.305 or later).
 - PowerShell 7+ (or Bash) to execute the documented commands.

--- a/benchmarks/RoutingEngine.Benchmarks/BaselineBenchmarks.cs
+++ b/benchmarks/RoutingEngine.Benchmarks/BaselineBenchmarks.cs
@@ -35,7 +35,7 @@ public class BaselineBenchmarks
     private static RoutingContext CreateContext()
     {
         var payment = new PaymentContext(PaymentDirection.Out, "EUR");
-        var counterparty = new CounterpartyContext("US", "ACMEUS33XXX", null, "ACME OFFSHORE");
+    var counterparty = new CounterpartyContext("US", "ACMEUS33XXX", null, "ACME OFFSHORE", CounterpartyType.Business);
     var customer = new CustomerContext("CUST-042", "FINTECH", CustomerType.Corporate, "DE44500105175407324931");
         return new RoutingContext(payment, counterparty, customer);
     }

--- a/config/rules.sample.json
+++ b/config/rules.sample.json
@@ -24,6 +24,16 @@
     "PR.CPartyName": "ACME OFFSHORE"
   },
   {
+    "RuleCodeName": "RULE-BUSINESS-ONLY",
+    "RuleDescription": "Route only when counterparty is classified as business.",
+    "OutcomePolicy": "PassOnMatch",
+    "Operator": "ALL",
+    "PriorityWeight": 400,
+    "CorrBankBic": "BNPAFRPPXXX",
+    "RuleStatus": "ON",
+    "PR.CPartyType": "BUSINESS"
+  },
+  {
     "RuleCodeName": "RULE-FALLBACK-DEFAULT",
     "RuleDescription": "Default corridor for unmatched outbound payments.",
     "OutcomePolicy": "PassOnMatch",

--- a/specs/002-payment-routing/contracts/openapi.yaml
+++ b/specs/002-payment-routing/contracts/openapi.yaml
@@ -85,6 +85,9 @@ components:
         name:
           type: string
           maxLength: 140
+        type:
+          type: string
+          enum: [PERSON, BUSINESS, UNKNOWN]
     CustomerContext:
       type: object
       properties:

--- a/specs/002-payment-routing/spec.md
+++ b/specs/002-payment-routing/spec.md
@@ -42,6 +42,7 @@ Each rule is persisted as a flat structure. Fields below are optional unless fla
 | `PR.CPartyBankBIC` | string | ❌ | Valid BIC11 (e.g., `CHASUS33XXX`) | Uppercase alphanumeric. |
 | `PR.CPartyAccount` | string | ❌ | Up to 34 characters; IBAN or domestic account | Whitespace ignored for comparison. |
 | `PR.CPartyName` | string | ❌ | Up to 140 characters | Trimmed case-insensitive comparison. |
+| `PR.CPartyType` | string | ❌ | `PERSON`, `BUSINESS`, `UNKNOWN` | Derived attribute populated by enrichment. Exact match. |
 | `PR.CustomerId` | string | ❌ | Up to 64 characters | Exact match. |
 | `PR.CustomerIndustry` | string | ❌ | Enumerated codes (e.g., `I001`) | Case-insensitive match. |
 | `PR.CustomerType` | string | ❌ | `INDIVIDUAL`, `CORPORATE` | Normalize to uppercase (typo `COORPORATE` is treated as `CORPORATE`). |
@@ -109,7 +110,8 @@ The routing engine is exposed over HTTP.
       "bankCountryCode": "GR",
       "bankBic": "DEUTDEFFXXX",
       "account": "DE12345678901234567890",
-      "name": "ACME SUPPLIER"
+      "name": "ACME SUPPLIER",
+      "type": "BUSINESS"
     },
     "customer": {
       "id": "CUST-001",

--- a/src/RoutingEngine/Configuration/JsonRuleCatalogLoader.cs
+++ b/src/RoutingEngine/Configuration/JsonRuleCatalogLoader.cs
@@ -95,6 +95,7 @@ public sealed class JsonRuleCatalogLoader
             var ruleOperator = ParseRuleOperator(dto.Operator, prefix, errors);
             var ruleStatus = ParseRuleStatus(dto.RuleStatus, prefix, errors);
             var customerType = ParseCustomerType(dto.CustomerType, prefix, errors);
+            var counterpartyType = ParseCounterpartyType(dto.CounterpartyType, prefix, errors);
             var paymentDirection = ParsePaymentDirection(dto.PaymentDirection, prefix, errors);
 
             if (errors.Count > errorCheckpoint)
@@ -120,6 +121,7 @@ public sealed class JsonRuleCatalogLoader
                 CustomerId = NormalizeOptional(dto.CustomerId),
                 CustomerIndustry = NormalizeUpper(dto.CustomerIndustry),
                 CustomerType = customerType,
+                CounterpartyType = counterpartyType,
                 CustomerAccount = NormalizeOptional(dto.CustomerAccount),
                 PaymentDirection = paymentDirection,
                 PaymentCurrency = NormalizeUpper(dto.PaymentCurrency)
@@ -287,6 +289,9 @@ public sealed class JsonRuleCatalogLoader
         [JsonPropertyName("PR.CPartyName")]
         public string? CounterpartyName { get; init; }
 
+    [JsonPropertyName("PR.CPartyType")]
+    public string? CounterpartyType { get; init; }
+
         [JsonPropertyName("PR.CustomerId")]
         public string? CustomerId { get; init; }
 
@@ -304,5 +309,21 @@ public sealed class JsonRuleCatalogLoader
 
         [JsonPropertyName("PR.PaymentCurrency")]
         public string? PaymentCurrency { get; init; }
+    }
+
+    private static CounterpartyType? ParseCounterpartyType(string? value, string prefix, ICollection<string> errors)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return value.Trim().ToUpperInvariant() switch
+        {
+            "PERSON" => CounterpartyType.Person,
+            "BUSINESS" => CounterpartyType.Business,
+            "UNKNOWN" => CounterpartyType.Unknown,
+            _ => AddError<CounterpartyType?>(errors, prefix, "PR.CPartyType", value)
+        };
     }
 }

--- a/src/RoutingEngine/Domain/CounterpartyContext.cs
+++ b/src/RoutingEngine/Domain/CounterpartyContext.cs
@@ -7,4 +7,5 @@ namespace RoutingEngine.Domain;
 /// <param name="BankBic">Counterparty bank BIC.</param>
 /// <param name="Account">Counterparty account reference.</param>
 /// <param name="Name">Counterparty name, typically up to 140 characters.</param>
-public sealed record CounterpartyContext(string? BankCountryCode, string? BankBic, string? Account, string? Name);
+/// <param name="Type">Derived counterparty type (e.g., PERSON, BUSINESS, UNKNOWN).</param>
+public sealed record CounterpartyContext(string? BankCountryCode, string? BankBic, string? Account, string? Name, CounterpartyType? Type);

--- a/src/RoutingEngine/Domain/CounterpartyType.cs
+++ b/src/RoutingEngine/Domain/CounterpartyType.cs
@@ -1,0 +1,8 @@
+namespace RoutingEngine.Domain;
+
+public enum CounterpartyType
+{
+    Unknown = 0,
+    Person = 1,
+    Business = 2
+}

--- a/src/RoutingEngine/Domain/RoutingRule.cs
+++ b/src/RoutingEngine/Domain/RoutingRule.cs
@@ -38,6 +38,9 @@ public sealed record RoutingRule
     /// <summary>Counterparty name condition.</summary>
     public string? CounterpartyName { get; init; }
 
+    /// <summary>Derived counterparty type condition.</summary>
+    public CounterpartyType? CounterpartyType { get; init; }
+
     /// <summary>Initiating customer identifier condition.</summary>
     public string? CustomerId { get; init; }
 

--- a/src/RoutingEngine/Evaluation/RuleConditionFactory.cs
+++ b/src/RoutingEngine/Evaluation/RuleConditionFactory.cs
@@ -25,6 +25,10 @@ public sealed class RuleConditionFactory
         AppendPredicate(predicateList, rule.CounterpartyBankBic, ctx => _normalizer.Equals(ctx.Counterparty.BankBic, rule.CounterpartyBankBic));
         AppendPredicate(predicateList, rule.CounterpartyAccount, ctx => _normalizer.Equals(ctx.Counterparty.Account, rule.CounterpartyAccount));
         AppendPredicate(predicateList, rule.CounterpartyName, ctx => _normalizer.Equals(ctx.Counterparty.Name, rule.CounterpartyName));
+        if (rule.CounterpartyType is not null)
+        {
+            predicateList.Add(ctx => ctx.Counterparty.Type == rule.CounterpartyType);
+        }
         AppendPredicate(predicateList, rule.CustomerId, ctx => _normalizer.Equals(ctx.Customer.Id, rule.CustomerId));
         AppendPredicate(predicateList, rule.CustomerIndustry, ctx => _normalizer.Equals(ctx.Customer.Industry, rule.CustomerIndustry));
     AppendPredicate(predicateList, rule.CustomerAccount, ctx => _normalizer.Equals(ctx.Customer.Account, rule.CustomerAccount));

--- a/tests/RoutingEngine.Tests/Infrastructure/RoutingEngineTestHarness.cs
+++ b/tests/RoutingEngine.Tests/Infrastructure/RoutingEngineTestHarness.cs
@@ -38,11 +38,13 @@ internal static class RoutingEngineTestHarness
         var customerType = ParseEnum<CustomerType>(request.Customer.Type);
 
         var payment = new PaymentContext(paymentDirection, request.Payment.Currency);
+        var counterpartyType = ParseEnum<CounterpartyType>(request.Counterparty.Type);
         var counterparty = new CounterpartyContext(
             request.Counterparty.BankCountryCode,
             request.Counterparty.BankBic,
             request.Counterparty.Account,
-            request.Counterparty.Name);
+            request.Counterparty.Name,
+            counterpartyType);
         var customer = new CustomerContext(
             request.Customer.Id,
             request.Customer.Industry,
@@ -260,6 +262,6 @@ public sealed record RoutingRequestDto(
 
 public sealed record PaymentDto(string Direction, string Currency);
 
-public sealed record CounterpartyDto(string? BankCountryCode, string? BankBic, string? Account, string? Name);
+public sealed record CounterpartyDto(string? BankCountryCode, string? BankBic, string? Account, string? Name, string? Type);
 
 public sealed record CustomerDto(string? Id, string? Industry, string? Type, string? Account);

--- a/tests/RoutingEngine.Tests/Infrastructure/RoutingRequestFactory.cs
+++ b/tests/RoutingEngine.Tests/Infrastructure/RoutingRequestFactory.cs
@@ -26,6 +26,7 @@ internal static class RoutingRequestFactory
         private string? _bankBic;
         private string? _account;
         private string? _name;
+        private string? _type;
 
         public CounterpartyBuilder WithBankCountryCode(string value)
         {
@@ -51,7 +52,13 @@ internal static class RoutingRequestFactory
             return this;
         }
 
-        public CounterpartyDto Build() => new(_bankCountryCode, _bankBic, _account, _name);
+        public CounterpartyBuilder WithType(string value)
+        {
+            _type = value;
+            return this;
+        }
+
+        public CounterpartyDto Build() => new(_bankCountryCode, _bankBic, _account, _name, _type);
     }
 
     internal sealed class CustomerBuilder

--- a/tests/RoutingEngine.Tests/Infrastructure/RuleCatalogBuilder.cs
+++ b/tests/RoutingEngine.Tests/Infrastructure/RuleCatalogBuilder.cs
@@ -50,6 +50,11 @@ internal static class RuleCatalogBuilder
             map["PR.CPartyName"] = definition.CounterpartyName;
         }
 
+        if (!string.IsNullOrWhiteSpace(definition.CounterpartyType))
+        {
+            map["PR.CPartyType"] = definition.CounterpartyType;
+        }
+
         if (!string.IsNullOrWhiteSpace(definition.CustomerId))
         {
             map["PR.CustomerId"] = definition.CustomerId;
@@ -97,6 +102,7 @@ internal sealed record RuleDefinition
     public string? CounterpartyBankBic { get; init; }
     public string? CounterpartyAccount { get; init; }
     public string? CounterpartyName { get; init; }
+    public string? CounterpartyType { get; init; }
     public string? CustomerId { get; init; }
     public string? CustomerIndustry { get; init; }
     public string? CustomerType { get; init; }

--- a/tests/RoutingEngine.Tests/RuleEvaluationPropertyTests.cs
+++ b/tests/RoutingEngine.Tests/RuleEvaluationPropertyTests.cs
@@ -92,7 +92,8 @@ public sealed class RuleEvaluationPropertyTests
                 MaybeFrom(CountryPool),
                 MaybeFrom(BicPool),
                 Maybe($"ACCT-{_random.Next(10_000, 999_999)}"),
-                Maybe(PickFrom(new[] { "ACME LTD", "FOO BAR", "SANCTIONED ENTITY", "TRUSTED SUPPLIER" })));
+                Maybe(PickFrom(new[] { "ACME LTD", "FOO BAR", "SANCTIONED ENTITY", "TRUSTED SUPPLIER" })),
+                Maybe(PickFrom(new[] { "PERSON", "BUSINESS", "UNKNOWN" })));
 
             var customer = new CustomerDto(
                 Maybe($"CUST-{_random.Next(1, 999):000}"),

--- a/tests/RoutingEngine.Tests/RuleEvaluationSpec.cs
+++ b/tests/RoutingEngine.Tests/RuleEvaluationSpec.cs
@@ -243,6 +243,34 @@ public sealed class RuleEvaluationSpec
     }
 
     [Fact]
+    public async Task Counterparty_type_predicate_routes_when_type_matches()
+    {
+        var catalog = RuleCatalogBuilder.BuildJson(
+            new RuleDefinition
+            {
+                RuleCodeName = "RULE-CPTY-BUSINESS",
+                RuleDescription = "Route only for business counterparties",
+                OutcomePolicy = "PassOnMatch",
+                Operator = "ALL",
+                PriorityWeight = 120,
+                CorrBankBic = "BNPAFRPPXXX",
+                CounterpartyType = "BUSINESS"
+            });
+
+        var request = RoutingRequestFactory.Create(
+            direction: "OUT",
+            currency: "EUR",
+            counterparty: c => c.WithType("BUSINESS"));
+
+        var result = await RoutingEngineTestHarness.EvaluateAsync(catalog, request);
+
+        Assert.Equal("CAN_ROUTE", result.Decision);
+        var route = Assert.Single(result.GreenRoutes);
+        Assert.Equal("RULE-CPTY-BUSINESS", route.RuleCode);
+        Assert.Equal("BNPAFRPPXXX", route.CorrBankBic);
+    }
+
+    [Fact]
     public async Task All_green_corridors_are_returned_when_every_rule_passes()
     {
         var catalog = RuleCatalogBuilder.BuildJson(

--- a/tests/RoutingEngine.Tests/ScenarioSnapshotTests.cs
+++ b/tests/RoutingEngine.Tests/ScenarioSnapshotTests.cs
@@ -143,4 +143,41 @@ public sealed class ScenarioSnapshotTests
             .UseMethodName("Customer_specific_block_snapshot_is_verified")
             .UseDirectory("Snapshots");
     }
+
+    [Fact]
+    public async Task Counterparty_type_business_snapshot_is_verified()
+    {
+        var catalog = RuleCatalogBuilder.BuildJson(
+            new RuleDefinition
+            {
+                RuleCodeName = "RULE-BUSINESS-ONLY",
+                RuleDescription = "Route only when counterparty is classified as business.",
+                OutcomePolicy = "PassOnMatch",
+                Operator = "ALL",
+                PriorityWeight = 400,
+                CorrBankBic = "BNPAFRPPXXX",
+                CounterpartyType = "BUSINESS"
+            },
+            new RuleDefinition
+            {
+                RuleCodeName = "RULE-GENERIC-USD",
+                RuleDescription = "Generic USD route",
+                OutcomePolicy = "PassOnMatch",
+                Operator = "ALL",
+                PriorityWeight = 100,
+                CorrBankBic = "CHASUS33XXX",
+                PaymentCurrency = "USD"
+            });
+
+        var request = RoutingRequestFactory.Create(
+            direction: "OUT",
+            currency: "EUR",
+            counterparty: c => c.WithType("BUSINESS"));
+
+        var result = await RoutingEngineTestHarness.EvaluateAsync(catalog, request);
+
+        await Verifier.Verify(result)
+            .UseMethodName("Counterparty_type_business_snapshot_is_verified")
+            .UseDirectory("Snapshots");
+    }
 }

--- a/tests/RoutingEngine.Tests/Snapshots/ScenarioSnapshotTests.Counterparty_type_business_snapshot_is_verified.verified.txt
+++ b/tests/RoutingEngine.Tests/Snapshots/ScenarioSnapshotTests.Counterparty_type_business_snapshot_is_verified.verified.txt
@@ -1,0 +1,23 @@
+﻿{
+  Decision: CAN_ROUTE,
+  GreenRoutes: [
+    {
+      RuleCode: RULE-BUSINESS-ONLY,
+      CorrBankBic: BNPAFRPPXXX,
+      Description: Route only when counterparty is classified as business.
+    }
+  ],
+  AuditTrail: [
+    {
+      RuleCode: RULE-BUSINESS-ONLY,
+      Match: true,
+      OutcomePolicy: PassOnMatch
+    },
+    {
+      RuleCode: RULE-GENERIC-USD,
+      Match: false,
+      OutcomePolicy: PassOnMatch
+    }
+  ],
+  Status: EVALUATED
+}


### PR DESCRIPTION
Summary
- Implements Phase 1.1 Option 1 (preprocess enrichment) by introducing CounterpartyType on Counterparty context and PR.CPartyType rule predicate.

Key changes
- Domain: add CounterpartyType enum (Unknown | Person | Business); extend CounterpartyContext with Type; extend CustomerContext with Account; extend RoutingRule with CustomerAccount and CounterpartyType predicates.
- Loader: parse PR.CustomerAccount and PR.CPartyType from JSON rule catalog; robust enum parsing/normalization.
- Evaluator: add predicates for CustomerAccount and CounterpartyType matching.
- Tests: extend test harness/builders; property tests generate optional customer.account and counterparty.type; add spec-style test for Counterparty type match; add Verify snapshot scenario for business counterparty; all tests pass.
- Benchmarks/samples: update baseline inputs; add sample rules for PR.CustomerAccount and PR.CPartyType.
- Docs/specs: update payment routing spec and OpenAPI (customer.account, counterparty.type); README adds Enrichment (Phase 1.1) guidance.

Notes
- This implements the agreed Option 1: the host enriches request.counterparty.type up-front; engine consumes via PR.CPartyType.
- Snapshot baseline for the new scenario is added and verified.

Verification
- dotnet build succeeded; tests green locally (xUnit, Verify).

Review checklist
- [x] Builds locally (Debug/Release)
- [x] Unit tests pass locally (including Verify snapshots)
- [x] Spec and OpenAPI updated to reflect new fields
- [x] README updated with enrichment guidance
- [x] Sample rule catalog includes PR.CPartyType example
- [x] Benchmarks updated with CounterpartyType.Business context

How to test locally
1) dotnet build
2) dotnet test tests/RoutingEngine.Tests/RoutingEngine.Tests.csproj
3) Optionally run benchmarks project if desired